### PR TITLE
Add script to fetch Revenova docs

### DIFF
--- a/docs/Revenova Docs/EXTERNAL_LINKS.md
+++ b/docs/Revenova Docs/EXTERNAL_LINKS.md
@@ -1,0 +1,20 @@
+- **Salesforce Developer Documentation**  
+  https://help.salesforce.com/s/products/platform?language=en_US
+
+- **Estes Express API Developer Portal**  
+  https://developer.estes-express.com/
+
+- **ABF Freight (ArcBest) Shipping APIs**  
+  https://arcb.com/technology/shippers/API
+
+- **Ward Transport & Logistics API**  
+  https://wardtlctools.com/wardtrucking/apirequest/create
+
+- **A Duie Pyle Web Services**  
+  https://aduiepyle.com/resources/it-support/
+
+- **Saia Motor Freight Line Developer Portal**  
+  https://saiaprodapi.developer.azure-api.net/
+
+- **Southeastern Freight Lines Web Connect API**  
+  https://www.sefl.com/seflWebsite/technology/webConnect.jsp

--- a/fetch_revenova_docs.py
+++ b/fetch_revenova_docs.py
@@ -1,0 +1,72 @@
+import os
+import requests
+from urllib.parse import urlparse
+
+# List of Revenova documentation URLs
+URLS = [
+    "https://documents.revenova.com/docs/revenova-tms-release-notes",
+    "https://documents.revenova.com/docs/revenova-tms-installation-guide",
+    "https://documents.revenova.com/docs/data-dictionary",
+    "https://documents.revenova.com/docs/revenova-tms-web-services-guide",
+    "https://documents.revenova.com/docs/integrations",
+    "http://documents.revenova.com/docs/field-set-summary",
+    "https://documents.revenova.com/docs/lightning-web-components-lwcs",
+    "https://documents.revenova.com/docs/fleet-management-2",
+    "https://documents.revenova.com/docs/accounting-seed-1",
+    "https://documents.revenova.com/docs/payiq",
+    "https://documents.revenova.com/docs/revenova-tms-analytics-user-guide",
+]
+
+BASE_DIR = os.path.join("docs", "Revenova Docs")
+
+
+def fetch_and_save(url: str):
+    """Fetch a single URL and save its content under docs/Revenova Docs."""
+    parsed = urlparse(url)
+    # Use last segment of path as folder name, stripping any trailing slashes
+    segment = parsed.path.rstrip('/').split('/')[-1]
+    if not segment:
+        raise ValueError(f"Cannot determine folder name from URL: {url}")
+
+    folder_path = os.path.join(BASE_DIR, segment)
+    os.makedirs(folder_path, exist_ok=True)
+
+    # Determine output file extension
+    ext = ".pdf" if parsed.path.lower().endswith(".pdf") else ".html"
+    filename = os.path.join(folder_path, f"index{ext}")
+
+    print(f"Fetching {url} -> {filename}")
+    response = requests.get(url, timeout=30)
+    response.raise_for_status()
+
+    # Write the content to file in binary mode
+    with open(filename, "wb") as f:
+        f.write(response.content)
+
+
+def write_external_links():
+    """Write external developer portal links to EXTERNAL_LINKS.md."""
+    links = [
+        "- **Salesforce Developer Documentation**  \n  https://help.salesforce.com/s/products/platform?language=en_US",
+        "- **Estes Express API Developer Portal**  \n  https://developer.estes-express.com/",
+        "- **ABF Freight (ArcBest) Shipping APIs**  \n  https://arcb.com/technology/shippers/API",
+        "- **Ward Transport & Logistics API**  \n  https://wardtlctools.com/wardtrucking/apirequest/create",
+        "- **A Duie Pyle Web Services**  \n  https://aduiepyle.com/resources/it-support/",
+        "- **Saia Motor Freight Line Developer Portal**  \n  https://saiaprodapi.developer.azure-api.net/",
+        "- **Southeastern Freight Lines Web Connect API**  \n  https://www.sefl.com/seflWebsite/technology/webConnect.jsp",
+    ]
+
+    path = os.path.join(BASE_DIR, "EXTERNAL_LINKS.md")
+    os.makedirs(BASE_DIR, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write("\n".join(links))
+
+
+def main():
+    for url in URLS:
+        fetch_and_save(url)
+    write_external_links()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add Python script to fetch Revenova documentation pages and store them
- document relevant external developer portal links

## Testing
- `python3 -m py_compile fetch_revenova_docs.py`

------
https://chatgpt.com/codex/tasks/task_e_685c4087cf808322a89d6f9e6838f6a3